### PR TITLE
Aws budget template

### DIFF
--- a/budget/awsbudgetnotify.yaml
+++ b/budget/awsbudgetnotify.yaml
@@ -8,5 +8,35 @@ Parameters:
 		Type: String
 		Default: 60
 		Description: Budget limit amount
-	
+	Threshold:
+		Type: String
+		Default: 55
+		Description: Threshold for budget is set to trigger email a 55
 
+Resources:
+  AcoountBudget:
+    Type: "AWS::Budgets::Budget"
+    Properties:
+      Budget:
+        BudgetLimit:
+          Amount: !Ref Amount
+          Unit: USD
+        TimeUnit: MONTHLY
+        TimePeriod:
+          Start: 1225864800
+          End: 1926864800
+        BudgetType: COST
+        CostFilters:
+          AZ:
+            - us-east-1
+      NotificationsWithSubscribers:
+        - Notification:
+            NotificationType: ACTUAL
+            ComparisonOperator: GREATER_THAN
+            Threshold: !Ref Threshold
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: dharrison@mobilecutsbos.com
+Outputs:
+  BudgetId:
+    Value: !Ref AccountBudget

--- a/budget/awsbudgetnotify.yaml
+++ b/budget/awsbudgetnotify.yaml
@@ -1,0 +1,12 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: Template that will send out an email of AWS billing costs and when it goes over a certain amount.
+
+Parameters:
+	Amount:
+		Type: String
+		Default: 60
+		Description: Budget limit amount
+	
+

--- a/budget/awsbudgetnotify.yaml
+++ b/budget/awsbudgetnotify.yaml
@@ -4,39 +4,39 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Template that will send out an email of AWS billing costs and when it goes over a certain amount.
 
 Parameters:
-	Amount:
-		Type: String
-		Default: 60
-		Description: Budget limit amount
-	Threshold:
-		Type: String
-		Default: 55
-		Description: Threshold for budget is set to trigger email a 55
+  Amount:
+    Type: String
+    Default: 60
+    Description: Budget limit amount
+  Threshold:
+    Type: String
+    Default: 55
+    Description: Threshold for budget is set to trigger email a 55
 
 Resources:
-	AcoountBudget:
-		Type: "AWS::Budgets::Budget"
-		Properties:
-			Budget:
-				BudgetLimit:
-					Amount: !Ref Amount
-					Unit: USD
-				TimeUnit: MONTHLY
-				TimePeriod:
-					Start: 1225864800
-					End: 1926864800
-				BudgetType: COST
-				CostFilters:
-					AZ:
-						- us-east-1
-			NotificationsWithSubscribers:
-				- Notification:
-						NotificationType: ACTUAL
-						ComparisonOperator: GREATER_THAN
-						Threshold: !Ref Threshold
-					Subscribers:
-						- SubscriptionType: EMAIL
-							Address: dharrison@mobilecutsbos.com
+  AcoountBudget:
+    Type: "AWS::Budgets::Budget"
+    Properties:
+      Budget:
+        BudgetLimit:
+          Amount: !Ref Amount
+          Unit: USD
+        TimeUnit: MONTHLY
+        TimePeriod:
+          Start: 1225864800
+          End: 1926864800
+        BudgetType: COST
+        CostFilters:
+          AZ:
+            - us-east-1
+      NotificationsWithSubscribers:
+        - Notification:
+            NotificationType: ACTUAL
+            ComparisonOperator: GREATER_THAN
+            Threshold: !Ref Threshold
+          Subscribers:
+            - SubscriptionType: EMAIL
+              Address: dharrison@mobilecutsbos.com
 Outputs:
-	BudgetId:
-		Value: !Ref AccountBudget
+  BudgetId:
+    Value: !Ref AccountBudget

--- a/budget/awsbudgetnotify.yaml
+++ b/budget/awsbudgetnotify.yaml
@@ -14,29 +14,29 @@ Parameters:
 		Description: Threshold for budget is set to trigger email a 55
 
 Resources:
-  AcoountBudget:
-    Type: "AWS::Budgets::Budget"
-    Properties:
-      Budget:
-        BudgetLimit:
-          Amount: !Ref Amount
-          Unit: USD
-        TimeUnit: MONTHLY
-        TimePeriod:
-          Start: 1225864800
-          End: 1926864800
-        BudgetType: COST
-        CostFilters:
-          AZ:
-            - us-east-1
-      NotificationsWithSubscribers:
-        - Notification:
-            NotificationType: ACTUAL
-            ComparisonOperator: GREATER_THAN
-            Threshold: !Ref Threshold
-          Subscribers:
-            - SubscriptionType: EMAIL
-              Address: dharrison@mobilecutsbos.com
+	AcoountBudget:
+		Type: "AWS::Budgets::Budget"
+		Properties:
+			Budget:
+				BudgetLimit:
+					Amount: !Ref Amount
+					Unit: USD
+				TimeUnit: MONTHLY
+				TimePeriod:
+					Start: 1225864800
+					End: 1926864800
+				BudgetType: COST
+				CostFilters:
+					AZ:
+						- us-east-1
+			NotificationsWithSubscribers:
+				- Notification:
+						NotificationType: ACTUAL
+						ComparisonOperator: GREATER_THAN
+						Threshold: !Ref Threshold
+					Subscribers:
+						- SubscriptionType: EMAIL
+							Address: dharrison@mobilecutsbos.com
 Outputs:
-  BudgetId:
-    Value: !Ref AccountBudget
+	BudgetId:
+		Value: !Ref AccountBudget


### PR DESCRIPTION
Template that sets a budget for AWS account and the default amount is set to $60, but threshold is set to greaterthan 55.